### PR TITLE
fixed shadow for cardlist item on Android 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stryberventures/stryber-react-native-ui-components",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "main": "lib/commonjs/index.js",
   "react-native": "lib/module/index.js",
   "module": "lib/module/index.js",

--- a/src/components/CardList/ListItem.tsx
+++ b/src/components/CardList/ListItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Text, TouchableOpacity} from 'react-native';
+import {View, Text, TouchableOpacity } from 'react-native';
 
 import Card from '../Card';
 import Checkbox from '../Checkbox';
@@ -21,8 +21,11 @@ const ListItem: React.FC<IListItemProps> = props => {
   };
 
   return (
-    <TouchableOpacity onPress={toggleQuiz} disabled={!props.quiz}>
-      <Card background={props.cardBackground} shadow style={styles.cardStyle}>
+    <TouchableOpacity
+      style={styles.cardWraper}
+      onPress={toggleQuiz} 
+      disabled={!props.quiz}>
+      <Card style={styles.cardStyle}>
         {props.quiz && props.quizCounter && (
           <View style={styles.leftElementWrapper}>
             <View style={styles.quizWrapper}>

--- a/src/components/CardList/styles.ts
+++ b/src/components/CardList/styles.ts
@@ -1,4 +1,4 @@
-import {StyleSheet} from 'react-native';
+import {Platform, StyleSheet} from 'react-native';
 
 import {IListItemProps} from './ListItem';
 
@@ -26,6 +26,9 @@ export const getListItemStyles = (theme: any, props: IListItemProps) => {
   const quizBackground = props.quizBackground
     ? theme.colors[props.quizBackground] || props.quizBackground
     : theme.colors.primary;
+  const cardBackground = props.cardBackground
+    ? theme.colors[props.cardBackground] || props.cardBackground
+    : theme.colors.white;
   const cardBorderColor = props.isActive
     ? quizBackground
     : props.cardBackground
@@ -39,15 +42,27 @@ export const getListItemStyles = (theme: any, props: IListItemProps) => {
     : theme.colors.black;
 
   return StyleSheet.create({
-    cardStyle: {
-      borderWidth: 1,
-      borderColor: cardBorderColor,
+    cardWraper: {
+      alignSelf: 'center',
+      backgroundColor: cardBackground,
+      marginBottom: 15,
+      marginTop: 2,
       paddingVertical: theme.spaces.m,
       paddingHorizontal: theme.spaces.xs,
-      marginTop: 2,
-      marginBottom: theme.spaces.m,
-      width: '99%',
-      alignSelf: 'center',
+      width: '98%',
+      borderWidth: 1,
+      borderColor: cardBorderColor,
+      borderRadius: theme.sizes.radius,
+      shadowColor: theme.colors.black,
+      shadowOffset: {
+        width: 0,
+        height: 4,
+      },
+      shadowOpacity: Platform.OS === 'ios' ? 0.25 : 0.5,
+      shadowRadius: 3.84,
+      elevation: 5
+    },
+    cardStyle: {
       flexDirection: 'row',
       alignItems: 'center',
     },


### PR DESCRIPTION
- fixed bug, reproduced only on Android 9 device. While pressing on one of the CardList items inner shadow appeared 